### PR TITLE
Hi fixed the blocking issue

### DIFF
--- a/lib/autotest/notify.rb
+++ b/lib/autotest/notify.rb
@@ -1,8 +1,9 @@
 class Autotest
   class Notify
     def self.notify(state)
-      title = "#{state.to_s.capitalize} -- Autotest"
-
+      pretty_state = state.to_s.capitalize
+      title = "#{pretty_state} -- Autotest"
+      
       command = case RUBY_PLATFORM
       when /linux/
         title = "'#{title}'"
@@ -12,7 +13,7 @@ class Autotest
         when :zenity then "#{linux_lib} --title #{title}"
         end
       when /darwin/
-        "growlnotify -n autotest -t #{title}"
+        "growlnotify -n autotest -m \"#{pretty_state}\" Autotest"
       when /cygwin/
         "sncmd /m '#{title}'"
       when /mswin/


### PR DESCRIPTION
The -m parameter needed to be passed aswell and I took the liberty to separate the title and the message as growl likes it.

Btw I have a failing test sometimes :) as in no changes just different runs.

linnea:autotest fonsan$ rake test
(in /Users/fonsan/autotest)
Loaded suite /Users/fonsan/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.......................................F............................
Finished in 5.395701 seconds.

  1) Failure:
test: integration green run should run in parallel. (TestAutotestIntegration) [test/test_autotest_integration.rb:90]:
Expected /YES/ to match "parallel_test '/Users/fonsan/autotest/test/tmp/test/test_a.rb' '/Users/fonsan/autotest/test/tmp/test/test_b.rb'\n4 processes for 2 tests, ~ 0 tests per process\nYEPLoaded sYuiEtSeL o-aed\neSdt asuitre -et\neSdt\na\nrFinishteedd \ni\nnF i0n.i0s0h0e1d7 5in  s0e.c0o0n0d1s9.6\n\n0 seconds.\n\n0 tests, 0 assertions, 0 failures, 0 errors, 0 skips\n\nTest run options: --seed 18575\n tests, 0 assertions, 0 failures, 0 errors, 0 skips\n\nTest run options: --seed 61369\n\nResults:\n0 tests, 0 assertions, 0 failures, 0 errors, 0 skips\n0 tests, 0 assertions, 0 failures, 0 errors, 0 skips\n\nTook 0.102178 seconds\nall_good".

68 tests, 128 assertions, 1 failures, 0 errors, 0 skips

Test run options: --seed 1769
