### PR TITLE
Removed Config deprecation warning.

### DIFF
--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -78,7 +78,7 @@ class Autotest
 
   HOOKS = Hash.new { |h,k| h[k] = [] } #unfound keys are []
   unless defined? WINDOZE then
-    WINDOZE = /mswin|mingw|windows/ =~ Config::CONFIG['host_os']
+    WINDOZE = /mswin|mingw|windows/ =~ RbConfig::CONFIG['host_os']
     SEP = WINDOZE ? '&' : ';'
   end
 
@@ -636,8 +636,8 @@ class Autotest
 
   def ruby
     ruby = ENV['RUBY']
-    ruby ||= File.join(Config::CONFIG['bindir'],
-                       Config::CONFIG['ruby_install_name'])
+    ruby ||= File.join(RbConfig::CONFIG['bindir'],
+                       RbConfig::CONFIG['ruby_install_name'])
 
     ruby.gsub! File::SEPARATOR, File::ALT_SEPARATOR if File::ALT_SEPARATOR
 

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -30,7 +30,7 @@ class TestAutotest < Test::Unit::TestCase
   end unless respond_to? :refute
   alias :deny :refute
 
-  RUBY = File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name']) unless defined? RUBY
+  RUBY = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) unless defined? RUBY
 
   def setup
     @test_class = 'TestBlah'


### PR DESCRIPTION
Hi! Running Ruby 1.9.3-dev it's giving me some warnings. Since Ruby 1.8.7 also recognizes the RbConfig constant, I replaced all references to it.

Tried running tests, but it failed on parallel tests, but the warnings were gone. So I don't really know why those tests are failing.
