### PR TITLE
Fix autotest/restart - updated file set is a hash.

### DIFF
--- a/lib/autotest/restart.rb
+++ b/lib/autotest/restart.rb
@@ -1,6 +1,6 @@
 module Autotest::Restart
-  Autotest.add_hook :updated do |at, *args|
-    if args.flatten.include? ".autotest" then
+  Autotest.add_hook :updated do |at, files_updated|
+    if files_updated.keys.include? ".autotest" then
       warn "Detected change to .autotest, restarting"
       cmd = %w(autotest)
       cmd << " -v" if $v


### PR DESCRIPTION
Hi,

Quick fix for autotest/restart...

The splat syntax on args was making auto-restart never work. The `:updated` hook provides a single argument, which is a hash. Flattening the hash would have worked, but flattening 'args' just returns an array containing a Hash.

Cheers,
--bpo
