### PR TITLE
Add delay option to command line to make it react quicker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,7 @@ Usage
     -r, --rc CONFIG                  Path to config file. (Defaults to ~/.autotest or current_dir/.autotest)
     -s, --style STYLE                Which style to use, e.g. rspec, rspec2
     -b, --bundle-exec                Use bundle exec to run tests
+    -d, --delay SECONDS              Delay time from file change to test run
     -n, --notify                     Notify about success and failure via popups
     -h, --help                       Show this.
 

--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -141,6 +141,11 @@ class Autotest
         require 'autotest/notify'
       end
 
+      # set to 0 with autotest-fsevent to make autotest react like guard
+      opts.on("-d", "--delay DELAY", "Delay time from file change to test run") do |delay|
+        options[:delay] = delay.to_i
+      end
+
       opts.on "-h", "--help", "Show this." do
         puts opts
         exit 1
@@ -281,7 +286,7 @@ class Autotest
     self.order             = :random
     self.output            = $stderr
     self.prefix            = nil
-    self.sleep             = 1
+    self.sleep             = options[:delay] || 1
     self.testlib           = "test/unit"
     self.find_directories  = ['.']
     self.unit_diff         = "ruby #{File.expand_path("#{File.dirname(__FILE__)}/../bin/unit_diff")} -u" # add ruby to also work for windows

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -453,6 +453,11 @@ test_error2(#{@test_class}):
     assert_equal expect, actual
   end
 
+  def test_sleep_option
+    result = Autotest.parse_options(['--delay','0'])
+    assert_equal result, {:delay=>0}
+  end
+
   def test_test_files_for
     assert_equal [@test], @a.test_files_for(@impl)
     assert_equal [@test], @a.test_files_for(@test)

--- a/test/test_autotest_integration.rb
+++ b/test/test_autotest_integration.rb
@@ -10,7 +10,7 @@ class TestAutotestIntegration < Test::Unit::TestCase
   def autotest_executable
     '../../bin/autotest'
   end
-  
+
   def run_autotest(flag_string='')
     `cd #{temp_dir} && #{autotest_executable} #{flag_string}`
   end
@@ -19,7 +19,7 @@ class TestAutotestIntegration < Test::Unit::TestCase
     file = "#{temp_dir}/#{file}"
     dir = File.dirname(file)
     `mkdir -p #{dir}` unless File.directory?(dir)
-    File.open(file, 'w'){|f| f.write text } 
+    File.open(file, 'w'){|f| f.write text }
   end
 
   def write_passing_tests times
@@ -90,6 +90,14 @@ class TestAutotestIntegration < Test::Unit::TestCase
         assert_match %r{YES}, result
         assert_match %r{YEP}, result
       end
+
+      should 'use a sleep option from .autotest' do
+        # speed up autotest to react instantly on save like Guard
+        run_autotest("--delay 0")
+        a = Autotest.new
+        assert_equal a.sleep, 0
+      end
+
     end
   end
 end


### PR DESCRIPTION
... to file changes when using autotest-fsevent so to be more Guard-like.
IE: do `autotest --delay 0`

I tried lots of implementations and unfortunately this one is the cleanest and least disruptive one that I could get working.  Another idea would be to detect if autotest-fsevent is available and just set the sleep to 0.  I could work on that if you don't like this implementation.
