### PR TITLE
Support ruby >=2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 group :dev do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
     git (1.2.5)

--- a/lib/autotest.rb
+++ b/lib/autotest.rb
@@ -381,7 +381,7 @@ class Autotest
       open("| #{cmd}", "r") do |f|
         until f.eof? do
           c = f.getc or break
-          putc (c.is_a?(Fixnum) ? c.chr : c) # print breaks coloring on windows -> putc
+          putc (c.is_a?(Integer) ? c.chr : c) # print breaks coloring on windows -> putc
           line << c
           if c == ?\n then
             self.results << if RUBY19 then
@@ -584,7 +584,7 @@ class Autotest
   end
 
   def ruby_cmd
-    "#{prefix}#{ruby} -I#{libs} -rubygems"
+    "#{prefix}#{ruby} -I#{libs} -rrubygems"
   end
 
   def escape_filenames(classes)

--- a/test/test_autotest.rb
+++ b/test/test_autotest.rb
@@ -312,7 +312,7 @@ test_error2(#{@test_class}):
     assert_equal empty, @a.files_to_test
 
     s3 = '
-/opt/bin/ruby -I.:lib:test -rubygems -e "%w[test/unit #{@test}].each { |f| require f }" | unit_diff -u
+/opt/bin/ruby -I.:lib:test -rrubygems -e "%w[test/unit #{@test}].each { |f| require f }" | unit_diff -u
 -e:1:in `require\': ./#{@test}:23: parse error, unexpected tIDENTIFIER, expecting \'}\' (SyntaxError)
     settings_fields.each {|e| assert_equal e, version.send e.intern}
                                                             ^   from -e:1
@@ -374,7 +374,7 @@ test_error2(#{@test_class}):
     }
 
     unit_diff = "ruby #{File.expand_path("#{File.dirname(__FILE__)}/../bin/unit_diff")}"
-    pre = "#{RUBY} -I.:lib:test -rubygems"
+    pre = "#{RUBY} -I.:lib:test -rrubygems"
     req = ".each { |f| require f }\""
     post = "| #{unit_diff} -u"
 

--- a/test/test_unit_diff.rb
+++ b/test/test_unit_diff.rb
@@ -86,7 +86,7 @@ Expected nil to equal "baz":
                    main.load at kernel/core/compile.rb:150
           main.__script__ {} at last_mspec.rb:11
                Array#each {} at kernel/core/array.rb:545
-       Integer(Fixnum)#times at kernel/core/integer.rb:15
+       Integer#times at kernel/core/integer.rb:15
                   Array#each at kernel/core/array.rb:545
              main.__script__ at last_mspec.rb:16
     CompiledMethod#as_script at kernel/bootstrap/primitives.rb:41


### PR DESCRIPTION
`autotest` was silently swallowing an exception on doing a comparison with `Fixnum`, which [was removed from Ruby in version 2.4](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/).

I've just replaced `Fixnum` with `Integer`.

I also took the opportunity to modernize a couple of RubyGems things:
- Update source in the Gemfile to use HTTPS
- Update all references to `-rubygems` to `-rrubygems`, as `ubygems.rb` went away in RubyGems 3.2